### PR TITLE
[feat] 멤버 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ out/
 
 ### Kotlin ###
 .kotlin
+
+### MacOs ###
+.Ds_Store
+.src/.Ds_Store

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,9 +26,17 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     runtimeOnly("com.h2database:h2")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+
+    // test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("io.mockk:mockk:1.13.5")
+
+    // kotest
+    testImplementation("io.kotest:kotest-runner-junit5:5.9.0")
+    testImplementation("io.kotest:kotest-assertions-core:5.9.0")
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.3.0")
 }
 
 kotlin {

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/domain/Member.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/domain/Member.kt
@@ -1,0 +1,13 @@
+package demo.kotlinpractice.domain.member.domain
+
+class Member(
+    private val id: Long,
+    private val name: String,
+    private val password: String,
+) {
+    fun getId(): Long = id
+
+    fun getName(): String = name
+
+    fun getPassword(): String = password
+}

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/domain/Member.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/domain/Member.kt
@@ -2,12 +2,17 @@ package demo.kotlinpractice.domain.member.domain
 
 class Member(
     private val id: Long,
-    private val name: String,
-    private val password: String,
+    private var name: String,
+    private var password: String,
 ) {
     fun getId(): Long = id
 
     fun getName(): String = name
 
     fun getPassword(): String = password
+
+    fun updateInfo(name: String, password: String): Unit {
+        this.name = name
+        this.password = password
+    }
 }

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/domain/repository/MemberRepository.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/domain/repository/MemberRepository.kt
@@ -3,6 +3,7 @@ package demo.kotlinpractice.domain.member.domain.repository
 import demo.kotlinpractice.domain.member.domain.Member
 
 interface MemberRepository {
+
     fun findById(id: Long): Member
 
     fun existsByName(name: String): Boolean

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/domain/repository/MemberRepository.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/domain/repository/MemberRepository.kt
@@ -1,0 +1,11 @@
+package demo.kotlinpractice.domain.member.domain.repository
+
+import demo.kotlinpractice.domain.member.domain.Member
+
+interface MemberRepository {
+    fun findById(id: Long): Member
+
+    fun existsByName(name: String): Boolean
+
+    fun save(member: Member): Member
+}

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/infra/MemberEntity.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/infra/MemberEntity.kt
@@ -40,4 +40,6 @@ class MemberEntity(
     fun getId(): Long = id
 
     fun getName(): String = name
+
+    fun getPassword(): String = password
 }

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/infra/MemberEntity.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/infra/MemberEntity.kt
@@ -1,0 +1,43 @@
+package demo.kotlinpractice.domain.member.infra
+
+import demo.kotlinpractice.domain.member.domain.Member
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+@Entity(name = "member")
+class MemberEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private val id: Long = 0,
+
+    @Column(nullable = false)
+    private val name: String,
+
+    @Column(nullable = false)
+    private val password: String
+) {
+    fun toDomain(): Member {
+        return Member(
+            id = id,
+            name = name,
+            password = password
+        )
+    }
+
+    companion object {
+        fun from(member: Member): MemberEntity {
+            return MemberEntity(
+                id = member.getId(),
+                name = member.getName(),
+                password = member.getPassword(),
+            )
+        }
+    }
+
+    fun getId(): Long = id
+
+    fun getName(): String = name
+}

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/infra/repository/MemberJPARepository.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/infra/repository/MemberJPARepository.kt
@@ -1,0 +1,9 @@
+package demo.kotlinpractice.domain.member.infra.repository
+
+import demo.kotlinpractice.domain.member.infra.MemberEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberJPARepository : JpaRepository<MemberEntity, Long> {
+
+    fun existsByName(name: String): Boolean
+}

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/infra/repository/MemberJPARepositoryAdaptor.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/infra/repository/MemberJPARepositoryAdaptor.kt
@@ -1,0 +1,24 @@
+package demo.kotlinpractice.domain.member.infra.repository
+
+import demo.kotlinpractice.domain.member.domain.Member
+import demo.kotlinpractice.domain.member.domain.repository.MemberRepository
+import demo.kotlinpractice.domain.member.infra.MemberEntity
+import kotlin.jvm.optionals.getOrNull
+
+class MemberJPARepositoryAdaptor(
+    private val memberJPARepository: MemberJPARepository
+) : MemberRepository {
+
+    override fun findById(id: Long): Member {
+        return memberJPARepository.findById(id).getOrNull()?.toDomain()
+            ?: throw IllegalArgumentException()
+    }
+
+    override fun existsByName(name: String): Boolean {
+        return memberJPARepository.existsByName(name)
+    }
+
+    override fun save(member: Member): Member {
+        return memberJPARepository.save(MemberEntity.from(member)).toDomain()
+    }
+}

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/infra/repository/MemberJPARepositoryAdaptor.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/infra/repository/MemberJPARepositoryAdaptor.kt
@@ -3,8 +3,10 @@ package demo.kotlinpractice.domain.member.infra.repository
 import demo.kotlinpractice.domain.member.domain.Member
 import demo.kotlinpractice.domain.member.domain.repository.MemberRepository
 import demo.kotlinpractice.domain.member.infra.MemberEntity
+import org.springframework.stereotype.Repository
 import kotlin.jvm.optionals.getOrNull
 
+@Repository
 class MemberJPARepositoryAdaptor(
     private val memberJPARepository: MemberJPARepository
 ) : MemberRepository {

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/port/in/MemberUseCase.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/port/in/MemberUseCase.kt
@@ -2,10 +2,13 @@ package demo.kotlinpractice.domain.member.port.`in`
 
 import demo.kotlinpractice.domain.member.domain.Member
 import demo.kotlinpractice.domain.member.presentation.dto.request.MemberCreateRequest
+import demo.kotlinpractice.domain.member.presentation.dto.request.MemberUpdateRequest
 
 interface MemberUseCase {
 
     fun createMember(request: MemberCreateRequest): Member
 
     fun findMember(memberId: Long): Member
+
+    fun updateMember(request: MemberUpdateRequest): Member
 }

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/port/in/MemberUseCase.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/port/in/MemberUseCase.kt
@@ -6,4 +6,6 @@ import demo.kotlinpractice.domain.member.presentation.dto.request.MemberCreateRe
 interface MemberUseCase {
 
     fun createMember(request: MemberCreateRequest): Member
+
+    fun findMember(memberId: Long): Member
 }

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/port/in/MemberUseCase.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/port/in/MemberUseCase.kt
@@ -1,0 +1,9 @@
+package demo.kotlinpractice.domain.member.port.`in`
+
+import demo.kotlinpractice.domain.member.domain.Member
+import demo.kotlinpractice.domain.member.presentation.dto.request.MemberCreateRequest
+
+interface MemberUseCase {
+
+    fun createMember(request: MemberCreateRequest): Member
+}

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/MemberController.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/MemberController.kt
@@ -1,10 +1,12 @@
 package demo.kotlinpractice.domain.member.presentation
 
 import demo.kotlinpractice.domain.member.presentation.dto.request.MemberCreateRequest
+import demo.kotlinpractice.domain.member.presentation.dto.request.MemberUpdateRequest
 import demo.kotlinpractice.domain.member.presentation.dto.response.MemberResponse
 import demo.kotlinpractice.domain.member.presentation.facade.MemberFacade
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -28,5 +30,12 @@ class MemberController(
             ResponseEntity<MemberResponse> {
 
         return ResponseEntity.ok(memberFacade.findMember(memberId))
+    }
+
+    @PatchMapping
+    fun updateMember(@RequestBody request: MemberUpdateRequest):
+            ResponseEntity<MemberResponse> {
+
+        return ResponseEntity.ok(memberFacade.updateMember(request))
     }
 }

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/MemberController.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/MemberController.kt
@@ -1,0 +1,23 @@
+package demo.kotlinpractice.domain.member.presentation
+
+import demo.kotlinpractice.domain.member.presentation.dto.request.MemberCreateRequest
+import demo.kotlinpractice.domain.member.presentation.dto.response.MemberResponse
+import demo.kotlinpractice.domain.member.presentation.facade.MemberFacade
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/member")
+class MemberController(
+    private val memberFacade: MemberFacade
+) {
+    @PostMapping
+    fun createMember(@RequestBody request: MemberCreateRequest):
+            ResponseEntity<MemberResponse> {
+        return ResponseEntity.ok(memberFacade.createMember(request))
+
+    }
+}

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/MemberController.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/MemberController.kt
@@ -4,6 +4,8 @@ import demo.kotlinpractice.domain.member.presentation.dto.request.MemberCreateRe
 import demo.kotlinpractice.domain.member.presentation.dto.response.MemberResponse
 import demo.kotlinpractice.domain.member.presentation.facade.MemberFacade
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,7 +19,14 @@ class MemberController(
     @PostMapping
     fun createMember(@RequestBody request: MemberCreateRequest):
             ResponseEntity<MemberResponse> {
-        return ResponseEntity.ok(memberFacade.createMember(request))
 
+        return ResponseEntity.ok(memberFacade.createMember(request))
+    }
+
+    @GetMapping("/{memberId}")
+    fun findMember(@PathVariable(value = "memberId") memberId: Long):
+            ResponseEntity<MemberResponse> {
+
+        return ResponseEntity.ok(memberFacade.findMember(memberId))
     }
 }

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/dto/request/MemberCreateRequest.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/dto/request/MemberCreateRequest.kt
@@ -1,0 +1,6 @@
+package demo.kotlinpractice.domain.member.presentation.dto.request
+
+data class MemberCreateRequest(
+    val name: String,
+    val password: String,
+)

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/dto/request/MemberUpdateRequest.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/dto/request/MemberUpdateRequest.kt
@@ -1,0 +1,7 @@
+package demo.kotlinpractice.domain.member.presentation.dto.request
+
+data class MemberUpdateRequest(
+    val memberId: Long,
+    val name: String,
+    val password: String
+)

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/dto/response/MemberResponse.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/dto/response/MemberResponse.kt
@@ -1,0 +1,17 @@
+package demo.kotlinpractice.domain.member.presentation.dto.response
+
+import demo.kotlinpractice.domain.member.domain.Member
+
+data class MemberResponse(
+    val id: Long,
+    val name: String,
+) {
+    companion object {
+        fun of(member: Member): MemberResponse {
+            return MemberResponse(
+                id = member.getId(),
+                name = member.getName(),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/facade/MemberFacade.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/facade/MemberFacade.kt
@@ -1,0 +1,18 @@
+package demo.kotlinpractice.domain.member.presentation.facade
+
+import demo.kotlinpractice.domain.member.domain.Member
+import demo.kotlinpractice.domain.member.port.`in`.MemberUseCase
+import demo.kotlinpractice.domain.member.presentation.dto.request.MemberCreateRequest
+import demo.kotlinpractice.domain.member.presentation.dto.response.MemberResponse
+import org.springframework.stereotype.Service
+
+@Service
+class MemberFacade(
+    private final val memberUseCase: MemberUseCase
+) {
+    fun createMember(request: MemberCreateRequest): MemberResponse {
+        val member: Member = memberUseCase.createMember(request)
+
+        return MemberResponse.of(member)
+    }
+}

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/facade/MemberFacade.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/facade/MemberFacade.kt
@@ -3,6 +3,7 @@ package demo.kotlinpractice.domain.member.presentation.facade
 import demo.kotlinpractice.domain.member.domain.Member
 import demo.kotlinpractice.domain.member.port.`in`.MemberUseCase
 import demo.kotlinpractice.domain.member.presentation.dto.request.MemberCreateRequest
+import demo.kotlinpractice.domain.member.presentation.dto.request.MemberUpdateRequest
 import demo.kotlinpractice.domain.member.presentation.dto.response.MemberResponse
 import org.springframework.stereotype.Service
 
@@ -19,6 +20,11 @@ class MemberFacade(
     fun findMember(memberId: Long): MemberResponse {
         val member: Member = memberUseCase.findMember(memberId)
 
+        return MemberResponse.of(member)
+    }
+
+    fun updateMember(request: MemberUpdateRequest): MemberResponse {
+        val member: Member = memberUseCase.updateMember(request)
         return MemberResponse.of(member)
     }
 }

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/facade/MemberFacade.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/facade/MemberFacade.kt
@@ -15,4 +15,10 @@ class MemberFacade(
 
         return MemberResponse.of(member)
     }
+
+    fun findMember(memberId: Long): MemberResponse {
+        val member: Member = memberUseCase.findMember(memberId)
+
+        return MemberResponse.of(member)
+    }
 }

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/service/MemberService.kt
@@ -1,0 +1,24 @@
+package demo.kotlinpractice.domain.member.service
+
+import demo.kotlinpractice.domain.member.domain.Member
+import demo.kotlinpractice.domain.member.domain.repository.MemberRepository
+import demo.kotlinpractice.domain.member.port.`in`.MemberUseCase
+import demo.kotlinpractice.domain.member.presentation.dto.request.MemberCreateRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class MemberService(
+    private val memberRepository: MemberRepository
+): MemberUseCase {
+
+    @Transactional
+    override fun createMember(request: MemberCreateRequest): Member {
+        val member = Member(
+            id = 0,
+            name = request.name,
+            password = request.password
+        )
+        return memberRepository.save(member)
+    }
+}

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/service/MemberService.kt
@@ -21,4 +21,9 @@ class MemberService(
         )
         return memberRepository.save(member)
     }
+
+    @Transactional(readOnly = true)
+    override fun findMember(memberId: Long): Member {
+        return memberRepository.findById(memberId)
+    }
 }

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/service/MemberService.kt
@@ -4,6 +4,7 @@ import demo.kotlinpractice.domain.member.domain.Member
 import demo.kotlinpractice.domain.member.domain.repository.MemberRepository
 import demo.kotlinpractice.domain.member.port.`in`.MemberUseCase
 import demo.kotlinpractice.domain.member.presentation.dto.request.MemberCreateRequest
+import demo.kotlinpractice.domain.member.presentation.dto.request.MemberUpdateRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -25,5 +26,13 @@ class MemberService(
     @Transactional(readOnly = true)
     override fun findMember(memberId: Long): Member {
         return memberRepository.findById(memberId)
+    }
+
+    @Transactional
+    override fun updateMember(request: MemberUpdateRequest): Member {
+        val member = findMember(request.memberId)
+        member.updateInfo(request.name, request.password)
+
+        return memberRepository.save(member)
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=KotlinPractice

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,22 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:h2:mem:kotlinpractice
+    username: root
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true
+
+  h2:
+    console:
+      enabled: true

--- a/src/test/kotlin/demo/kotlinpractice/domain/member/domain/MemberTest.kt
+++ b/src/test/kotlin/demo/kotlinpractice/domain/member/domain/MemberTest.kt
@@ -1,0 +1,21 @@
+package demo.kotlinpractice.domain.member.domain
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class MemberTest : StringSpec({
+    "get 메서드를 통한 멤버 클래스 특성 조회는 올바른 값을 반환해야한다." {
+        // Given
+        val id = 1L
+        val name = "jwnnoh"
+        val password = "password"
+
+        // When
+        val member = Member(id, name, password)
+
+        // Then
+        member.getId() shouldBe id
+        member.getName() shouldBe name
+        member.getPassword() shouldBe password
+    }
+})

--- a/src/test/kotlin/demo/kotlinpractice/domain/member/infra/MemberEntityTest.kt
+++ b/src/test/kotlin/demo/kotlinpractice/domain/member/infra/MemberEntityTest.kt
@@ -1,0 +1,39 @@
+package demo.kotlinpractice.domain.member.infra
+
+import demo.kotlinpractice.domain.member.domain.Member
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class MemberEntityTest: StringSpec({
+    "toDomain 메서드를 통해 Member 객체를 반환할 수 있어야 한다." {
+        // Given
+        val id = 1L
+        val name = "jwnnoh"
+        val password = "password"
+
+        // When
+        val memberEntity = MemberEntity(id, name, password)
+        val member = memberEntity.toDomain()
+
+        // Then
+        member.getId() shouldBe id
+        member.getName() shouldBe name
+        member.getPassword() shouldBe password
+    }
+
+    "from 메서드를 통해 Member 객체로부터 MemberEntity를 반환할 수 있어야 한다. " {
+        // Given
+        val id = 1L
+        val name = "jwnnoh"
+        val password = "password"
+
+        // When
+        val member = Member(id, name, password)
+        val memberEntity = MemberEntity.from(member)
+
+        // Then
+        memberEntity.getId() shouldBe id
+        memberEntity.getName() shouldBe name
+        memberEntity.getPassword() shouldBe password
+    }
+})

--- a/src/test/kotlin/demo/kotlinpractice/domain/member/presentation/MemberControllerTest.kt
+++ b/src/test/kotlin/demo/kotlinpractice/domain/member/presentation/MemberControllerTest.kt
@@ -1,0 +1,93 @@
+package demo.kotlinpractice.domain.member.presentation
+
+import demo.kotlinpractice.domain.member.presentation.dto.request.MemberCreateRequest
+import demo.kotlinpractice.domain.member.presentation.dto.request.MemberUpdateRequest
+import demo.kotlinpractice.domain.member.presentation.dto.response.MemberResponse
+import demo.kotlinpractice.domain.member.presentation.facade.MemberFacade
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.http.ResponseEntity
+
+class MemberControllerTest : StringSpec({
+    "DTO를 통한 멤버 생성의 반환은 정상적으로 이루어져야 한다." {
+        // Given
+        val name = "jwnnoh"
+        val password = "password"
+        val request = MemberCreateRequest(name, password)
+        val response = MemberResponse(1L, name)
+
+        // Mock
+        val memberFacade: MemberFacade = mockk<MemberFacade>()
+        val memberController = MemberController(memberFacade)
+
+        // Stub
+        every { memberFacade.createMember(any()) } returns response
+
+        // When
+        val httpResponse: ResponseEntity<MemberResponse> = memberController.createMember(request)
+
+        // Then
+        httpResponse.body?.id shouldBe 1L
+        httpResponse.body?.name shouldBe name
+
+        // Verify & Confirm
+        verify(exactly = 1) { memberFacade.createMember(any()) }
+        confirmVerified(memberFacade)
+    }
+
+    "memberId를 통한 Member 조회는 정상적으로 이루어져야 한다." {
+        // Given
+        val memberId = 1L
+        val name = "jwnnoh"
+        val response = MemberResponse(memberId, name)
+
+        // Mock
+        val memberFacade = mockk<MemberFacade>()
+        val memberController = MemberController(memberFacade)
+
+        // Stub
+        every { memberFacade.findMember(any()) } returns response
+
+        // When
+        val httpResponse: ResponseEntity<MemberResponse> = memberController.findMember(memberId)
+
+        // Then
+        httpResponse.body?.id shouldBe 1L
+        httpResponse.body?.name shouldBe name
+
+        // Verify & Confirm
+        verify(exactly = 1) { memberFacade.findMember(any()) }
+        confirmVerified(memberFacade)
+    }
+
+    "name, password를 통한 수정된 멤버의 반환은 정상적으로 이루어져야 한다." {
+        // Given
+        val memberId = 1L
+        val name = "jwnnoh"
+        val password = "password"
+        val request = MemberUpdateRequest(memberId, name, password)
+        val response = MemberResponse(memberId, name)
+
+        // Mock
+        val memberFacade = mockk< MemberFacade>()
+        val memberController = MemberController(memberFacade)
+
+        // Stub
+        every { memberFacade.updateMember(any()) } returns response
+
+        // When
+        val httpResponse: ResponseEntity<MemberResponse> = memberController.updateMember(request)
+
+        // Then
+        httpResponse.body?.id shouldBe 1L
+        httpResponse.body?.name shouldBe name
+
+        // Verify & Confirm
+        verify(exactly = 1) { memberFacade.updateMember(any()) }
+        confirmVerified(memberFacade)
+    }
+})

--- a/src/test/kotlin/demo/kotlinpractice/domain/member/presentation/dto/response/MemberResponseTest.kt
+++ b/src/test/kotlin/demo/kotlinpractice/domain/member/presentation/dto/response/MemberResponseTest.kt
@@ -1,0 +1,22 @@
+package demo.kotlinpractice.domain.member.presentation.dto.response
+
+import demo.kotlinpractice.domain.member.domain.Member
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class MemberResponseTest: StringSpec({
+    "MemberResponseDTO는 Member을 변수로 받아 정상적으로 자신의 타입으로 변환해야 한다." {
+        // Given
+        val memberId = 1L
+        val name = "jwnnoh"
+        val password = "password"
+        val member = Member(memberId, name, password)
+
+        // When
+        val response = MemberResponse.of(member)
+
+        // Then
+        response.id shouldBe memberId
+        response.name shouldBe name
+    }
+})

--- a/src/test/kotlin/demo/kotlinpractice/domain/member/service/MemberServiceTest.kt
+++ b/src/test/kotlin/demo/kotlinpractice/domain/member/service/MemberServiceTest.kt
@@ -1,0 +1,69 @@
+package demo.kotlinpractice.domain.member.service
+
+import demo.kotlinpractice.domain.member.domain.Member
+import demo.kotlinpractice.domain.member.domain.repository.MemberRepository
+import demo.kotlinpractice.domain.member.presentation.dto.request.MemberCreateRequest
+import demo.kotlinpractice.domain.member.presentation.dto.request.MemberUpdateRequest
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.*
+
+class MemberServiceTest : StringSpec({
+
+    "이름과 비밀번호를 통해 멤버가 정상적으로 생성되고 반환되어야 한다" {
+        // Given
+        val name = "jwnnoh"
+        val password = "password"
+        val request = MemberCreateRequest(name, password)
+
+        // Mock
+        val memberRepository: MemberRepository = mockk<MemberRepository>()
+        val memberService = MemberService(memberRepository)
+
+        val member = Member(1L, name, password)
+
+        // Stub
+        every { memberRepository.save(any()) } returns member
+
+        // When
+        val savedMember: Member = memberService.createMember(request)
+
+        // Then
+        savedMember.getId() shouldBe member.getId()
+        savedMember.getName() shouldBe member.getName()
+        savedMember.getPassword() shouldBe member.getPassword()
+
+        // Verify & Confirm
+        verify(exactly = 1) { memberRepository.save(any()) }
+        confirmVerified(memberRepository)
+    }
+
+    "이름과 비밀번호는 updateInfo 메서드를 통해 정상적으로 수정되어야 한다." {
+        // Given
+        val memberId = 1L
+        val newName = "newName"
+        val newPassword = "newPassword"
+        val member = Member(memberId, "jwnnoh", "password")
+        val request = MemberUpdateRequest(memberId, newName, newPassword)
+
+        // Mock
+        val memberRepository: MemberRepository = mockk<MemberRepository>()
+        val memberService = MemberService(memberRepository)
+
+        // Stub
+        every { memberRepository.findById(any()) } returns member
+        every { memberRepository.save(any()) } returns member
+
+        // When
+        val updatedMember: Member = memberService.updateMember(request)
+
+        // Then
+        updatedMember.getName() shouldBe newName
+        updatedMember.getPassword() shouldBe newPassword
+
+        // Verify & Confirm
+        verify(exactly = 1) { memberRepository.findById(any()) }
+        verify(exactly = 1) { memberRepository.save(any()) }
+        confirmVerified(memberRepository)
+    }
+})


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 테스트 코드 추가

---

## ✏️ 작업 내용

### 멤버 생성 기능 추가
- Create: name, password를 통한 멤버 객체를 생성할 수 있습니다.
- Read: Id를 통해 생성한 member 객체를 조회할 수 있습니다.
- Update: Id를 통해 조회한 member의 name, password를 변경할 수 있습니다.

### 엔티티 구조
> 도메인 클래스와 엔티티 클래스를 분리하여 구현하였습니다. 이는 추후 ORM 방식이 변경될 수도 있음을 유의한 결과입니다.

#### Data Class를 지양한 이유
Data Class는 `equals()`, `hashcode()`, `toString()` 등 다양한 메서드를 기본으로 지원해 준다는 장점이 존재합니다.
다만 해당 방식은 `lazy loading`의 적용이 불가하며, JPA를 활용하려면 해당 메서드들을 전부 오버라이드 해주어야 한다는 단점을 지닙니다.
dirty check 또한 사용이 어렵다는 점이 무척 치명적..ㅠㅠ
  
### 변수 선언 방식 
- 불변한 값(id)는 val로 선언하였습니다.
- 변경 가능한 값은 var로 선언하였습니다.
- 접근 제어자 권한을 private으로 설정하였지만, JPA의 엔티티 규칙에 맞는 지는 아직 의문입니다.

---

## 🔗 관련 이슈
- closes #1 

---

## 💡 의의
> Kotlin을 통한 스프링 부트 프레임워크 + JPA 활용에 익숙해지기 위함입니다.

- 파사드 + 어댑터 및 클린 아키텍쳐를 동시에 공부하면서 코드에 적용하고자 합니다.
- 추후 멀티모듈로 변경 예정입니다.