### PR TITLE
[feat] JWT 인증-인가 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,14 +24,22 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    runtimeOnly("com.h2database:h2")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    runtimeOnly("com.mysql:mysql-connector-j")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+
+    //jjwt
+    implementation("io.jsonwebtoken:jjwt-api:0.12.6")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
 
     // test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("io.mockk:mockk:1.13.5")
+    testRuntimeOnly("com.h2database:h2")
+    testImplementation("org.springframework.security:spring-security-test")
 
     // kotest
     testImplementation("io.kotest:kotest-runner-junit5:5.9.0")

--- a/src/main/kotlin/demo/kotlinpractice/domain/auth/AuthDetails.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/auth/AuthDetails.kt
@@ -8,17 +8,22 @@ import java.util.Collections
 data class AuthDetails(
     private val id: Long,
     private val name: String,
+    private val password: String,
     private val role: String
 ): UserDetails {
     override fun getAuthorities(): Collection<GrantedAuthority?> {
         return Collections.singletonList(SimpleGrantedAuthority("ROLE_USER"))
     }
 
-    override fun getPassword(): String? {
-        return null
+    override fun getPassword(): String {
+        return password
     }
 
-    override fun getUsername(): String? {
+    override fun getUsername(): String {
         return name
+    }
+
+    fun getId(): Long {
+        return id
     }
 }

--- a/src/main/kotlin/demo/kotlinpractice/domain/auth/AuthDetails.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/auth/AuthDetails.kt
@@ -1,0 +1,24 @@
+package demo.kotlinpractice.domain.auth
+
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+import java.util.Collections
+
+data class AuthDetails(
+    private val id: Long,
+    private val name: String,
+    private val role: String
+): UserDetails {
+    override fun getAuthorities(): Collection<GrantedAuthority?> {
+        return Collections.singletonList(SimpleGrantedAuthority("ROLE_USER"))
+    }
+
+    override fun getPassword(): String? {
+        return null
+    }
+
+    override fun getUsername(): String? {
+        return name
+    }
+}

--- a/src/main/kotlin/demo/kotlinpractice/domain/auth/AuthDetailsService.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/auth/AuthDetailsService.kt
@@ -10,6 +10,6 @@ class AuthDetailsService(
 ): UserDetailsService {
     override fun loadUserByUsername(name: String): AuthDetails {
         val member = memberRepository.findByName(name)
-        return AuthDetails(member.getId(), member.getName(), "ROLE_USER")
+        return AuthDetails(member.getId(), member.getName(), member.getPassword(), "ROLE_USER")
     }
 }

--- a/src/main/kotlin/demo/kotlinpractice/domain/auth/AuthDetailsService.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/auth/AuthDetailsService.kt
@@ -1,0 +1,15 @@
+package demo.kotlinpractice.domain.auth
+
+import demo.kotlinpractice.domain.member.domain.repository.MemberRepository
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.stereotype.Service
+
+@Service
+class AuthDetailsService(
+    private val memberRepository: MemberRepository
+): UserDetailsService {
+    override fun loadUserByUsername(name: String): AuthDetails {
+        val member = memberRepository.findByName(name)
+        return AuthDetails(member.getId(), member.getName(), "ROLE_USER")
+    }
+}

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/domain/repository/MemberRepository.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/domain/repository/MemberRepository.kt
@@ -9,4 +9,6 @@ interface MemberRepository {
     fun existsByName(name: String): Boolean
 
     fun save(member: Member): Member
+
+    fun findByName(name: String): Member
 }

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/infra/repository/MemberJPARepository.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/infra/repository/MemberJPARepository.kt
@@ -1,9 +1,13 @@
 package demo.kotlinpractice.domain.member.infra.repository
 
+import demo.kotlinpractice.domain.member.domain.Member
 import demo.kotlinpractice.domain.member.infra.MemberEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
 
 interface MemberJPARepository : JpaRepository<MemberEntity, Long> {
 
     fun existsByName(name: String): Boolean
+
+    fun findByName(name: String): Optional<Member>
 }

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/infra/repository/MemberJPARepositoryAdaptor.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/infra/repository/MemberJPARepositoryAdaptor.kt
@@ -23,4 +23,9 @@ class MemberJPARepositoryAdaptor(
     override fun save(member: Member): Member {
         return memberJPARepository.save(MemberEntity.from(member)).toDomain()
     }
+
+    override fun findByName(name: String): Member {
+        return memberJPARepository.findByName(name).getOrNull()
+            ?: throw IllegalArgumentException()
+    }
 }

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/port/in/MemberUseCase.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/port/in/MemberUseCase.kt
@@ -1,8 +1,10 @@
 package demo.kotlinpractice.domain.member.port.`in`
 
 import demo.kotlinpractice.domain.member.domain.Member
+import demo.kotlinpractice.domain.member.presentation.dto.request.LoginRequest
 import demo.kotlinpractice.domain.member.presentation.dto.request.MemberCreateRequest
 import demo.kotlinpractice.domain.member.presentation.dto.request.MemberUpdateRequest
+import demo.kotlinpractice.domain.member.presentation.dto.response.LoginResponse
 
 interface MemberUseCase {
 
@@ -11,4 +13,6 @@ interface MemberUseCase {
     fun findMember(memberId: Long): Member
 
     fun updateMember(request: MemberUpdateRequest): Member
+
+    fun loginMember(request: LoginRequest): LoginResponse
 }

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/MemberController.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/MemberController.kt
@@ -1,5 +1,6 @@
 package demo.kotlinpractice.domain.member.presentation
 
+import demo.kotlinpractice.domain.auth.AuthDetails
 import demo.kotlinpractice.domain.member.presentation.dto.request.LoginRequest
 import demo.kotlinpractice.domain.member.presentation.dto.request.MemberCreateRequest
 import demo.kotlinpractice.domain.member.presentation.dto.request.MemberUpdateRequest
@@ -7,9 +8,9 @@ import demo.kotlinpractice.domain.member.presentation.dto.response.LoginResponse
 import demo.kotlinpractice.domain.member.presentation.dto.response.MemberResponse
 import demo.kotlinpractice.domain.member.presentation.facade.MemberFacade
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
-import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -27,11 +28,11 @@ class MemberController(
         return ResponseEntity.ok(memberFacade.createMember(request))
     }
 
-    @GetMapping("/{memberId}")
-    fun findMember(@PathVariable(value = "memberId") memberId: Long):
+    @GetMapping("/info")
+    fun findMember(@AuthenticationPrincipal authDetails: AuthDetails):
             ResponseEntity<MemberResponse> {
 
-        return ResponseEntity.ok(memberFacade.findMember(memberId))
+        return ResponseEntity.ok(memberFacade.findMember(authDetails))
     }
 
     @PatchMapping

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/MemberController.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/MemberController.kt
@@ -1,7 +1,9 @@
 package demo.kotlinpractice.domain.member.presentation
 
+import demo.kotlinpractice.domain.member.presentation.dto.request.LoginRequest
 import demo.kotlinpractice.domain.member.presentation.dto.request.MemberCreateRequest
 import demo.kotlinpractice.domain.member.presentation.dto.request.MemberUpdateRequest
+import demo.kotlinpractice.domain.member.presentation.dto.response.LoginResponse
 import demo.kotlinpractice.domain.member.presentation.dto.response.MemberResponse
 import demo.kotlinpractice.domain.member.presentation.facade.MemberFacade
 import org.springframework.http.ResponseEntity
@@ -16,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/member")
 class MemberController(
-    private val memberFacade: MemberFacade
+    private val memberFacade: MemberFacade,
 ) {
     @PostMapping
     fun createMember(@RequestBody request: MemberCreateRequest):
@@ -37,5 +39,12 @@ class MemberController(
             ResponseEntity<MemberResponse> {
 
         return ResponseEntity.ok(memberFacade.updateMember(request))
+    }
+
+    @PostMapping("/login")
+    fun login(@RequestBody request: LoginRequest):
+            ResponseEntity<LoginResponse> {
+
+        return ResponseEntity.ok(memberFacade.loginMember(request))
     }
 }

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/dto/request/LoginRequest.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/dto/request/LoginRequest.kt
@@ -1,0 +1,6 @@
+package demo.kotlinpractice.domain.member.presentation.dto.request
+
+data class LoginRequest(
+    val name: String,
+    val password: String
+)

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/dto/response/LoginResponse.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/dto/response/LoginResponse.kt
@@ -1,0 +1,6 @@
+package demo.kotlinpractice.domain.member.presentation.dto.response
+
+data class LoginResponse(
+    val memberId: Long,
+    val accessToken: String
+)

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/facade/MemberFacade.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/facade/MemberFacade.kt
@@ -2,6 +2,8 @@ package demo.kotlinpractice.domain.member.presentation.facade
 
 import demo.kotlinpractice.domain.member.domain.Member
 import demo.kotlinpractice.domain.member.port.`in`.MemberUseCase
+import demo.kotlinpractice.domain.member.presentation.dto.request.LoginRequest
+import demo.kotlinpractice.domain.member.presentation.dto.response.LoginResponse
 import demo.kotlinpractice.domain.member.presentation.dto.request.MemberCreateRequest
 import demo.kotlinpractice.domain.member.presentation.dto.request.MemberUpdateRequest
 import demo.kotlinpractice.domain.member.presentation.dto.response.MemberResponse
@@ -26,5 +28,9 @@ class MemberFacade(
     fun updateMember(request: MemberUpdateRequest): MemberResponse {
         val member: Member = memberUseCase.updateMember(request)
         return MemberResponse.of(member)
+    }
+
+    fun loginMember(request: LoginRequest): LoginResponse {
+        return memberUseCase.loginMember(request)
     }
 }

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/facade/MemberFacade.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/presentation/facade/MemberFacade.kt
@@ -1,5 +1,6 @@
 package demo.kotlinpractice.domain.member.presentation.facade
 
+import demo.kotlinpractice.domain.auth.AuthDetails
 import demo.kotlinpractice.domain.member.domain.Member
 import demo.kotlinpractice.domain.member.port.`in`.MemberUseCase
 import demo.kotlinpractice.domain.member.presentation.dto.request.LoginRequest
@@ -19,8 +20,8 @@ class MemberFacade(
         return MemberResponse.of(member)
     }
 
-    fun findMember(memberId: Long): MemberResponse {
-        val member: Member = memberUseCase.findMember(memberId)
+    fun findMember(authDetails: AuthDetails): MemberResponse {
+        val member: Member = memberUseCase.findMember(authDetails.getId())
 
         return MemberResponse.of(member)
     }

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/service/MemberService.kt
@@ -5,20 +5,21 @@ import demo.kotlinpractice.domain.member.domain.repository.MemberRepository
 import demo.kotlinpractice.domain.member.port.`in`.MemberUseCase
 import demo.kotlinpractice.domain.member.presentation.dto.request.MemberCreateRequest
 import demo.kotlinpractice.domain.member.presentation.dto.request.MemberUpdateRequest
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class MemberService(
-    private val memberRepository: MemberRepository
+    private val memberRepository: MemberRepository,
+    private val passwordEncoder: PasswordEncoder
 ): MemberUseCase {
-
     @Transactional
     override fun createMember(request: MemberCreateRequest): Member {
         val member = Member(
             id = 0,
             name = request.name,
-            password = request.password
+            password = passwordEncoder.encode(request.password)
         )
         return memberRepository.save(member)
     }

--- a/src/main/kotlin/demo/kotlinpractice/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/demo/kotlinpractice/domain/member/service/MemberService.kt
@@ -3,8 +3,11 @@ package demo.kotlinpractice.domain.member.service
 import demo.kotlinpractice.domain.member.domain.Member
 import demo.kotlinpractice.domain.member.domain.repository.MemberRepository
 import demo.kotlinpractice.domain.member.port.`in`.MemberUseCase
+import demo.kotlinpractice.domain.member.presentation.dto.request.LoginRequest
 import demo.kotlinpractice.domain.member.presentation.dto.request.MemberCreateRequest
 import demo.kotlinpractice.domain.member.presentation.dto.request.MemberUpdateRequest
+import demo.kotlinpractice.domain.member.presentation.dto.response.LoginResponse
+import demo.kotlinpractice.global.jwt.AuthenticationService
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -12,7 +15,8 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class MemberService(
     private val memberRepository: MemberRepository,
-    private val passwordEncoder: PasswordEncoder
+    private val passwordEncoder: PasswordEncoder,
+    private val authenticationService: AuthenticationService
 ): MemberUseCase {
     @Transactional
     override fun createMember(request: MemberCreateRequest): Member {
@@ -35,5 +39,10 @@ class MemberService(
         member.updateInfo(request.name, request.password)
 
         return memberRepository.save(member)
+    }
+
+    @Transactional
+    override fun loginMember(request: LoginRequest): LoginResponse {
+       return authenticationService.authenticate(request)
     }
 }

--- a/src/main/kotlin/demo/kotlinpractice/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/demo/kotlinpractice/global/config/SecurityConfig.kt
@@ -1,0 +1,16 @@
+package demo.kotlinpractice.global.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.crypto.factory.PasswordEncoderFactories
+import org.springframework.security.crypto.password.PasswordEncoder
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig() {
+    @Bean
+    fun passwordEncoder(): PasswordEncoder {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder()
+    }
+}

--- a/src/main/kotlin/demo/kotlinpractice/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/demo/kotlinpractice/global/config/SecurityConfig.kt
@@ -1,16 +1,48 @@
 package demo.kotlinpractice.global.config
 
+import demo.kotlinpractice.global.jwt.JwtAuthorizationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.factory.PasswordEncoderFactories
 import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.web.DefaultSecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
 @EnableWebSecurity
-class SecurityConfig() {
+class SecurityConfig {
+    @Bean
+    fun securityFilterChain(
+        http: HttpSecurity,
+        jwtAuthenticationFilter: JwtAuthorizationFilter
+    ): DefaultSecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .authorizeHttpRequests {
+                it
+                    .requestMatchers("/**")
+                    .permitAll()
+                    .anyRequest()
+                    .permitAll()
+            }
+            .sessionManagement {
+                it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            }
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+        return http.build()
+    }
+
     @Bean
     fun passwordEncoder(): PasswordEncoder {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder()
     }
+
+    @Bean
+    fun authenticationManager(config: AuthenticationConfiguration): AuthenticationManager =
+        config.authenticationManager
 }

--- a/src/main/kotlin/demo/kotlinpractice/global/jwt/AuthenticationService.kt
+++ b/src/main/kotlin/demo/kotlinpractice/global/jwt/AuthenticationService.kt
@@ -1,0 +1,46 @@
+package demo.kotlinpractice.global.jwt
+
+import demo.kotlinpractice.domain.auth.AuthDetailsService
+import demo.kotlinpractice.domain.member.presentation.dto.request.LoginRequest
+import demo.kotlinpractice.domain.member.presentation.dto.response.LoginResponse
+import io.jsonwebtoken.Claims
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.stereotype.Service
+import java.util.Collections
+
+@Service
+class AuthenticationService(
+    private val jwtProvider: JwtProvider,
+    private val authDetailsService: AuthDetailsService,
+    private val authenticationManager: AuthenticationManager
+) {
+    fun authenticate(request: LoginRequest): LoginResponse {
+        authenticationManager.authenticate(
+            UsernamePasswordAuthenticationToken(
+                request.name,
+                request.password
+            )
+        )
+
+        val authDetails = authDetailsService.loadUserByUsername(request.name)
+
+        val accessToken = jwtProvider.generateAccessToken(
+            authDetails.getId(),
+            authDetails.username,
+            authDetails.authorities.toString()
+        )
+
+        return LoginResponse(authDetails.getId(), accessToken)
+    }
+
+    fun getAuthentication(token: String): Authentication {
+        val claims: Claims = jwtProvider.extractAllClaims(token)
+        val authorities: Collection<GrantedAuthority?> = Collections.singletonList(SimpleGrantedAuthority("ROLE_USER"))
+
+        return UsernamePasswordAuthenticationToken(jwtProvider.getAuthDetails(claims), "", authorities)
+    }
+}

--- a/src/main/kotlin/demo/kotlinpractice/global/jwt/JwtAuthorizationFilter.kt
+++ b/src/main/kotlin/demo/kotlinpractice/global/jwt/JwtAuthorizationFilter.kt
@@ -1,0 +1,42 @@
+package demo.kotlinpractice.global.jwt
+
+import demo.kotlinpractice.domain.auth.AuthDetailsService
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.jetbrains.annotations.NotNull
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class JwtAuthorizationFilter(
+    private val authenticationService: AuthenticationService
+): OncePerRequestFilter() {
+    private val headerPrefix: String = "Authorization"
+    private val tokenPrefix: String = "Bearer "
+
+    override fun doFilterInternal(
+        @NotNull request: HttpServletRequest,
+        @NotNull response: HttpServletResponse,
+        @NotNull filterChain: FilterChain
+    ) {
+        val accessToken: String? = extractToken(request)
+
+        if (null != accessToken) {
+            val authentication: Authentication = this.authenticationService.getAuthentication(accessToken)
+            SecurityContextHolder.getContext().authentication = authentication
+        }
+        filterChain.doFilter(request, response)
+    }
+
+    private fun extractToken(request: HttpServletRequest): String? {
+        val authorizationHeader: String? = request.getHeader(headerPrefix)
+
+        if (null != authorizationHeader && authorizationHeader.startsWith(tokenPrefix)) {
+            return authorizationHeader.substringAfter(tokenPrefix)
+        }
+        return null
+    }
+}

--- a/src/main/kotlin/demo/kotlinpractice/global/jwt/JwtAuthorizationFilter.kt
+++ b/src/main/kotlin/demo/kotlinpractice/global/jwt/JwtAuthorizationFilter.kt
@@ -1,6 +1,5 @@
 package demo.kotlinpractice.global.jwt
 
-import demo.kotlinpractice.domain.auth.AuthDetailsService
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse

--- a/src/main/kotlin/demo/kotlinpractice/global/jwt/JwtProvider.kt
+++ b/src/main/kotlin/demo/kotlinpractice/global/jwt/JwtProvider.kt
@@ -1,0 +1,56 @@
+package demo.kotlinpractice.global.jwt
+
+import demo.kotlinpractice.domain.auth.AuthDetailsService
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.Jwts
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.util.Base64
+import java.util.Date
+import javax.crypto.spec.SecretKeySpec
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+
+@Service
+class JwtProvider(
+    private val authDetailsService: AuthDetailsService,
+    @Value("\${jwt.secret}") private val secret: String
+) {
+    private val accessTokenDuration: Duration = 1.days
+
+    private val secretKey: SecretKeySpec
+        get() {
+            val keyBytes: ByteArray = Base64.getDecoder().decode(secret)
+            return SecretKeySpec(keyBytes, "HmacSHA256")
+        }
+
+    fun generateAccessToken(memberId: Long, name: String, role: String): String {
+        return generateToken(memberId, name, accessTokenDuration, role)
+    }
+
+    private fun generateToken(
+        memberId: Long,
+        name: String,
+        duration: Duration,
+        role: String
+    ): String {
+        val now = Date()
+        val expiry = Date(now.time + duration.inWholeMilliseconds)
+
+        return Jwts.builder()
+            .subject(name)
+            .claim("id", memberId)
+            .claim("role", role)
+            .expiration(expiry)
+            .signWith(secretKey)
+            .compact()
+    }
+
+    fun extractAllClaims(token: String): Claims {
+        return Jwts.parser()
+            .verifyWith(secretKey)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+    }
+}

--- a/src/main/kotlin/demo/kotlinpractice/global/jwt/JwtProvider.kt
+++ b/src/main/kotlin/demo/kotlinpractice/global/jwt/JwtProvider.kt
@@ -1,5 +1,6 @@
 package demo.kotlinpractice.global.jwt
 
+import demo.kotlinpractice.domain.auth.AuthDetails
 import demo.kotlinpractice.domain.auth.AuthDetailsService
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jwts
@@ -52,5 +53,9 @@ class JwtProvider(
             .build()
             .parseSignedClaims(token)
             .getPayload()
+    }
+
+    fun getAuthDetails(claims: Claims): AuthDetails {
+        return authDetailsService.loadUserByUsername(claims.subject)
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,4 +18,4 @@ spring:
         use_sql_comments: true
 
 jwt:
-  secret:
+  secret: TestSecretKeyForJWTTokenTestSecretKeyForJWTToken

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,10 +3,10 @@ spring:
     activate:
       on-profile: local
   datasource:
-    url: jdbc:h2:mem:kotlinpractice
+    url: jdbc:mysql://localhost:3306/kotlinpractice
     username: root
     password:
-    driver-class-name: org.h2.Driver
+    driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     hibernate:
@@ -17,6 +17,5 @@ spring:
         format_sql: true
         use_sql_comments: true
 
-  h2:
-    console:
-      enabled: true
+jwt:
+  secret:


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용

### 인증 객체 구현
- UserDetails을 구현한 AuthDetails 객체를 구현하였습니다.
- 해당 인증 객체를 통해 인증된 사용자의 정보를 불러올 수 있습니다.

### 인증 방식
- 사용자가 최초 가입 시, `SecurityConfig`에 Bean으로 등록되어 있는 `PasswordEncoder`을 통해 비밀번호가 암호화되어 저장됩니다.
- 로그인 시, 마찬가지로 Bean으로 등록되어 있는 AuthenticationManager을 통해 인증 과정이 이루어지게 됩니다.
  - name, password를 통해 AuthenticationManager가 올바른 사용자 이름과 비밀번호와 일치되는지 확인합니다.
- 이후 authDetailsService를 통해 인증 객체를 전달받고, 해당 객체를 통해 토큰을 생성하여 반환합니다.

---

## 🔗 관련 이슈
- closes #3 

## 💡의의
코틀린 DSL 방식으로 Spring Security를 구현하기 위해서는
`org.springframework.security.config.annotation.web.invoke`
의존성을 꼭 import 해주어야 합니다. 